### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Model Context Protocol Server for Apache OpenDAL™
 A Model Context Protocol (MCP) server implementation that provides access to various storage services via [Apache OpenDAL™](https://opendal.apache.org/).
 
+<a href="https://glama.ai/mcp/servers/pwpk8kdcom">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/pwpk8kdcom/badge" alt="Server for Apache OpenDAL™ MCP server" />
+</a>
+
 [![PyPI - Version](https://img.shields.io/pypi/v/mcp-server-opendal)](https://pypi.org/project/mcp-server-opendal/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/mcp-server-opendal)](https://pypi.org/project/mcp-server-opendal/)
 [![Lint and Test](https://github.com/Xuanwo/mcp-server-opendal/actions/workflows/test.yml/badge.svg)](https://github.com/Xuanwo/mcp-server-opendal/actions/workflows/test.yml)


### PR DESCRIPTION
This PR adds a badge for the [MCP Server for Apache OpenDAL™](https://glama.ai/mcp/servers/pwpk8kdcom) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/pwpk8kdcom">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/pwpk8kdcom/badge" alt="Server for Apache OpenDAL™ MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.